### PR TITLE
Fix/strict parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ fetchcontent_declare(
 fetchcontent_makeavailable(googletest)
 enable_testing()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
 file(GLOB_RECURSE TEST_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp")
 add_executable(tests "${TEST_SRCS}")
 target_include_directories(tests PUBLIC "${JSON_EXT_INCLUDE_DIRS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,18 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(JSON_EXT_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
 
-# FIXME not sure whether this really is the minimum version I tested only with 1.81
+# FIXME not sure whether this really is the minimum version I tested only
+# with 1.81
 find_package(Boost 1.65.0)
 include_directories(${Boost_INCLUDE_DIRS})
 
 include(FetchContent)
-FetchContent_Declare(
+fetchcontent_declare(
   googletest
   DOWNLOAD_EXTRACT_TIMESTAMP true
   URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
 )
-FetchContent_MakeAvailable(googletest)
+fetchcontent_makeavailable(googletest)
 enable_testing()
 
 file(GLOB_RECURSE TEST_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp")

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,12 @@
+linelength=120
+set noparent
+# enable our include order, allow headers like <regex>, <thread>
+filter=-build/include_order,-build/c++
+# ignore that we don't have a copyright
+filter=-legal/copyright
+# ignore that todos are not bound to a person
+filter=-readability/todo
+# ignore that we pass references to functions
+filter=-runtime/reference,
+# ignore some style stuff
+filter=-whitespace/newline,-whitespace/parens,-whitespace/comments,-whitespace/braces,-whitespace/indent

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 
 all: test
 
+init:
+	paru -S lcov gcc cmake nlohmann-json boost perl-datetime
+
 build:
 	mkdir -p build && cd build \
 		&& cmake -DCMAKE_BUILD_TYPE=Debug .. \
@@ -13,5 +16,17 @@ build:
 test: build
 	./build/tests
 
+cov: build test
+	mkdir -p coverage \
+		&& lcov \
+			--directory build  \
+			--capture  \
+			--output-file coverage/coverage.info \
+			--ignore-errors mismatch \
+			--include "*/json_ext/*" \
+			--exclude "*/json_ext/tests" \
+			--exclude "gtest/" \
+		&& genhtml coverage/coverage.info --output-directory coverage
+
 clean:
-	rm -rf build
+	rm -rf build coverage

--- a/README.md
+++ b/README.md
@@ -51,47 +51,33 @@ int main()
 
 Will error out if you have more variables present in the json than on the class itself.
 
-Doesn't work 100% you can build an edge case, when mixing default values and required values (good enough for me with this I can parse an `std::variant` more safely).
+`NLOHMANN_SERIALIZE_STRICT`, will store the reflected keys.
+In `from_json` it will check whether every key in the json is also present in the reflected set of keys.
+This is particularly useful when you serialize a `std::variant`. 
+Image you have a `std::variant<TypeA, TypeB>` with:
 
 ```cpp
-#include <nlohmann/json_ext.hpp>
-
-struct serialize_me_daddy
+struct TypeA
 {
-    NLOHMANN_SERIALIZE_STRICT(serialize_me_daddy,
-        (int, required)
-    )
+    int a;
+    int b;
 };
 
-struct edge_case
+struct TypeB
 {
-    NLOHMANN_SERIALIZE_STRICT(edge_case,
-        (int, a, 1)
-    )
+    int a;
 };
-
-int main()
-{
-    // this is okay only required is present on the json
-    auto j1 = JSON({"required": 1337});
-    auto obj1 = j1.get<serialize_me_daddy>();
-
-    // this is not okay! more variables are present in the json than on the cls itself
-    auto j2 = JSON({"required": 1337, "optional": 43});
-    // auto obj2 = j2.get<serialize_me_daddy>();
-
-    // edge case will still work, was able to circumvent :(
-    auto j3 = JSON({"c": 3})
-    auto obj3 = j3.get<edge_case>();
-}
 ```
+
+Both have some intersections in their members, depending on the order which you have defined in the `std::variant`, and on the data, now either `TypeA`, or `TypeB` gets successfully deserialized.
+With strict this should not be an issue anymore.
 
 ## Run the tests
 
 ### Ubuntu
 
 ```bash
-sudo apt install -y libboost-dev
+sudo apt install -y libboost-dev cmake gcc
 # this library also expects that you have `nlohmann/json.hpp` in your include directories
 ```
 
@@ -99,7 +85,7 @@ sudo apt install -y libboost-dev
 
 ```bash
 # on Arch
-paru -Sy nlohmann-json boost
+paru -Sy nlohmann-json boost cmake gcc
 ```
 
 ### Compile and Run tests
@@ -110,6 +96,6 @@ make test
 
 ## TODOs
 
-- [ ] fix the edge case for variants
-- [ ] improve the counting of the supplied members, currently done at runtime, but all this information is available at compile time
+- [X] fix the edge case for variants
+- [X]  no counting done anymore ~~improve the counting of the supplied members, currently done at runtime, but all this information is available at compile time~~
 - [X] improve the serialization interface, it is possible to supply just a one dimensional array as in: `(int, a)(int, b)` instead of `((int, a))((int b))`

--- a/src/include/nlohmann/json_ext.hpp
+++ b/src/include/nlohmann/json_ext.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <optional>
+#include <string_view>
 #include <variant>
 
 #include <boost/preprocessor/facilities/is_empty_variadic.hpp>
@@ -8,7 +9,7 @@
 #include <nlohmann/adl_serializer.hpp>
 #include <nlohmann/json.hpp>
 
-#define JSON(...) nlohmann::json::parse(#__VA_ARGS__);
+#define JSON(...) nlohmann::json::parse(#__VA_ARGS__)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// SERIALIZATION std::variant
@@ -25,6 +26,8 @@ void variant_from_json(const nlohmann::json &j, std::variant<Ts...> &data, bool 
     }
     catch (...)
     {
+        // if we couldn't parse the variant we don't care, from outside we will just try
+        // the next one
     }
 }
 

--- a/src/include/nlohmann/json_ext.hpp
+++ b/src/include/nlohmann/json_ext.hpp
@@ -1,10 +1,13 @@
 #pragma once
 #include <optional>
+#include <string>
 #include <string_view>
 #include <variant>
+#include <vector>
 
 #include <boost/preprocessor/facilities/is_empty_variadic.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/stringize.hpp>
 
 #include <nlohmann/adl_serializer.hpp>
 #include <nlohmann/json.hpp>
@@ -136,26 +139,40 @@ template <typename T> struct nlohmann::adl_serializer<std::optional<T>>
                               BOOST_PP_CAT(CREATE_PLACEHOLDER_FILLER_0 var_types_and_names_and_maybe_values, _END))    \
     }
 
-#define _DEFINE_FROM_JSON_STRICT(R, data, var_types_and_names_and_maybe_values)                                        \
-    _DEFINE_FROM_JSON(R, data, var_types_and_names_and_maybe_values)                                                   \
-    ++var_count;
+#define __DEFINE_POSSIBLE_KEYS(var_type_and_name_and_maybe_value)                                                      \
+    BOOST_PP_STRINGIZE(GET_VARIABLE_NAME(var_type_and_name_and_maybe_value)),
+
+#define _DEFINE_POSSIBLE_KEYS(R, data, var_type_and_name_and_maybe_value)                                              \
+    __DEFINE_POSSIBLE_KEYS(var_type_and_name_and_maybe_value)
 
 #define DEFINE_FROM_JSON_STRICT(Type, var_types_and_names_and_maybe_values)                                            \
     friend void from_json(const nlohmann::json &nlohmann_json_j, Type &nlohmann_json_t)                                \
     {                                                                                                                  \
-        uint64_t var_count = 0;                                                                                        \
-        const Type nlohmann_json_default_obj{};                                                                        \
-        BOOST_PP_SEQ_FOR_EACH(_DEFINE_FROM_JSON_STRICT, _,                                                             \
-                              BOOST_PP_CAT(CREATE_PLACEHOLDER_FILLER_0 var_types_and_names_and_maybe_values, _END))    \
-        if (nlohmann_json_j.size() > var_count)                                                                        \
+        /* strict serialization stores the possible keys in the function, to check if additional keys are present */   \
+        static const std::vector<std::string> possible_keys = {BOOST_PP_SEQ_FOR_EACH(                                  \
+            _DEFINE_POSSIBLE_KEYS, _,                                                                                  \
+            BOOST_PP_CAT(CREATE_PLACEHOLDER_FILLER_0 var_types_and_names_and_maybe_values, _END))};                    \
+                                                                                                                       \
+        /* check that every key in our json, exists in the reflected keys of our serialized class */                   \
+        for (const auto &item : nlohmann_json_j.items())                                                               \
         {                                                                                                              \
-            throw nlohmann::detail::other_error::create(                                                               \
-                600,                                                                                                   \
-                nlohmann::detail::concat("type must have ", std::to_string(var_count), " args, but has ",              \
-                                         std::to_string(nlohmann_json_j.size()),                                       \
-                                         " args, error in: ", nlohmann_json_j.dump()),                                 \
-                &nlohmann_json_j);                                                                                     \
+            bool is_allowed_key =                                                                                      \
+                std::find(possible_keys.begin(), possible_keys.end(), item.key()) != possible_keys.end();              \
+            /* if an additional aka. non-allowed key is found kill the serialization */                                \
+            if (!is_allowed_key)                                                                                       \
+            {                                                                                                          \
+                throw nlohmann::detail::other_error::create(                                                           \
+                    600,                                                                                               \
+                    nlohmann::detail::concat("key '", item.key(),                                                      \
+                                             "' not present in reflected keys: ", nlohmann_json_j.dump()),             \
+                    &nlohmann_json_j);                                                                                 \
+            }                                                                                                          \
         }                                                                                                              \
+                                                                                                                       \
+        const Type nlohmann_json_default_obj{};                                                                        \
+        /* define the parsing as in the non-strict version */                                                          \
+        BOOST_PP_SEQ_FOR_EACH(_DEFINE_FROM_JSON, _,                                                                    \
+                              BOOST_PP_CAT(CREATE_PLACEHOLDER_FILLER_0 var_types_and_names_and_maybe_values, _END))    \
     }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/nlohmann_serialize_test.cpp
+++ b/tests/nlohmann_serialize_test.cpp
@@ -36,14 +36,14 @@ TEST(TestNlohmannSerialize, OkayDefaults)
     auto j = JSON({"a" : 1, "b" : 2});
 
     OnlyDefaults obj1;
-    EXPECT_EQ(1, obj1.a);
-    EXPECT_EQ(2, obj1.b);
-    EXPECT_EQ(j, static_cast<json>(obj1));
+    EXPECT_EQ(obj1.a, 1);
+    EXPECT_EQ(obj1.b, 2);
+    EXPECT_EQ(static_cast<json>(obj1), j);
 
     OnlyDefaultsStrict obj2;
-    EXPECT_EQ(1, obj2.a);
-    EXPECT_EQ(2, obj2.b);
-    EXPECT_EQ(j, static_cast<json>(obj2));
+    EXPECT_EQ(obj2.a, 1);
+    EXPECT_EQ(obj2.b, 2);
+    EXPECT_EQ(static_cast<json>(obj2), j);
 }
 
 TEST(TestNlohmannSerialize, OkayDefaultsFullOverride)
@@ -51,14 +51,14 @@ TEST(TestNlohmannSerialize, OkayDefaultsFullOverride)
     auto j = JSON({"a" : 3, "b" : 4});
 
     auto obj1 = j.get<OnlyDefaults>();
-    EXPECT_EQ(3, obj1.a);
-    EXPECT_EQ(4, obj1.b);
+    EXPECT_EQ(obj1.a, 3);
+    EXPECT_EQ(obj1.b, 4);
     EXPECT_EQ(j, static_cast<json>(obj1));
 
     auto obj2 = j.get<OnlyDefaultsStrict>();
-    EXPECT_EQ(3, obj2.a);
-    EXPECT_EQ(4, obj2.b);
-    EXPECT_EQ(j, static_cast<json>(obj2));
+    EXPECT_EQ(obj2.a, 3);
+    EXPECT_EQ(obj2.b, 4);
+    EXPECT_EQ(static_cast<json>(obj2), j);
 }
 
 TEST(TestNlohmannSerialize, OkayDefaultsPartialOverride)
@@ -66,12 +66,12 @@ TEST(TestNlohmannSerialize, OkayDefaultsPartialOverride)
     auto j = JSON({"b" : 4});
 
     auto obj1 = j.get<OnlyDefaults>();
-    EXPECT_EQ(1, obj1.a);
-    EXPECT_EQ(4, obj1.b);
+    EXPECT_EQ(obj1.a, 1);
+    EXPECT_EQ(obj1.b, 4);
 
     auto obj2 = j.get<OnlyDefaultsStrict>();
-    EXPECT_EQ(1, obj2.a);
-    EXPECT_EQ(4, obj2.b);
+    EXPECT_EQ(obj2.a, 1);
+    EXPECT_EQ(obj2.b, 4);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -101,14 +101,14 @@ TEST(TestNlohmannSerialize, OkayNonDefaultsFullOverride)
     auto j = JSON({"a" : 3, "b" : 4});
 
     auto obj1 = j.get<OnlyNonDefaults>();
-    EXPECT_EQ(3, obj1.a);
-    EXPECT_EQ(4, obj1.b);
-    EXPECT_EQ(j, static_cast<json>(obj1));
+    EXPECT_EQ(obj1.a, 3);
+    EXPECT_EQ(obj1.b, 4);
+    EXPECT_EQ(static_cast<json>(obj1), j);
 
     auto obj2 = j.get<OnlyNonDefaultsStrict>();
-    EXPECT_EQ(3, obj2.a);
-    EXPECT_EQ(4, obj2.b);
-    EXPECT_EQ(j, static_cast<json>(obj2));
+    EXPECT_EQ(obj2.a, 3);
+    EXPECT_EQ(obj2.b, 4);
+    EXPECT_EQ(static_cast<json>(obj2), j);
 }
 
 TEST(TestNlohmannSerialize, OkayNonDefaultsFullOverrideMore)
@@ -117,24 +117,23 @@ TEST(TestNlohmannSerialize, OkayNonDefaultsFullOverrideMore)
 
     // okay with non-strict
     auto obj1 = j.get<OnlyNonDefaults>();
-    EXPECT_EQ(3, obj1.a);
-    EXPECT_EQ(4, obj1.b);
+    EXPECT_EQ(obj1.a, 3);
+    EXPECT_EQ(obj1.b, 4);
 
     // fails with strict
-    EXPECT_EX("[json.exception.other_error.600] type must have 2 args, but has 3 args, error in:"
-              " {\"a\":3,\"b\":4,\"c\":5}",
-              j.get<OnlyNonDefaultsStrict>())
+    EXPECT_EX(j.get<OnlyNonDefaultsStrict>(),
+              "[json.exception.other_error.600] key 'c' not present in reflected keys: {\"a\":3,\"b\":4,\"c\":5}")
 }
 
 TEST(TestNlohmannSerialize, FailNonDefaultsValueMissing)
 {
     auto j = JSON({"a" : 3});
-    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<OnlyNonDefaults>())
-    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<OnlyNonDefaultsStrict>())
+    EXPECT_EX(j.get<OnlyNonDefaults>(), "[json.exception.out_of_range.403] key 'b' not found")
+    EXPECT_EX(j.get<OnlyNonDefaultsStrict>(), "[json.exception.out_of_range.403] key 'b' not found")
 
     j = JSON({"b" : 4});
-    EXPECT_EX("[json.exception.out_of_range.403] key 'a' not found", j.get<OnlyNonDefaults>())
-    EXPECT_EX("[json.exception.out_of_range.403] key 'a' not found", j.get<OnlyNonDefaultsStrict>())
+    EXPECT_EX(j.get<OnlyNonDefaults>(), "[json.exception.out_of_range.403] key 'a' not found")
+    EXPECT_EX(j.get<OnlyNonDefaultsStrict>(), "[json.exception.out_of_range.403] key 'a' not found")
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -174,14 +173,21 @@ TEST(TestNlohmannSerialize, OkayMixedDefaultNonDefault)
 
 TEST(TestNlohmannSerialize, FailMixedDefaultNonDefault)
 {
-    auto j = JSON({"c" : 3});
+    auto j1 = JSON({"c" : 3});
+    EXPECT_EX(j1.get<MixedDefaultNonDefault>(), "[json.exception.out_of_range.403] key 'b' not found")
 
-    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<MixedDefaultNonDefault>())
-    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<MixedDefaultNonDefaultStrict>())
+    // with strict this should fail before the key is checked
+    EXPECT_EX(j1.get<MixedDefaultNonDefaultStrict>(),
+              "[json.exception.other_error.600] key 'c' not present in reflected keys: {\"c\":3}")
+
+    // if it is empty it is fine with strict, still b is not present
+    auto j2 = JSON({});
+    EXPECT_EX(j2.get<MixedDefaultNonDefaultStrict>(), "[json.exception.out_of_range.403] key 'b' not found")
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// EDGE CASE WHICH CIRCUMVENTS STRICT :(
+/// OLD EDGE CASE
+/// should now be fixed
 struct StrictEdgeCase
 {
     NLOHMANN_SERIALIZE_STRICT(StrictEdgeCase, (int, a, 42))
@@ -190,11 +196,11 @@ struct StrictEdgeCase
 TEST(TestNlohmannSerialize, FailStrictEdgeCase)
 {
     auto j1 = JSON({"c" : 3});
-    auto obj1 = j1.get<StrictEdgeCase>();
-    EXPECT_EQ(42, obj1.a);
+    EXPECT_EX(j1.get<StrictEdgeCase>(),
+              "[json.exception.other_error.600] key 'c' not present in reflected keys: {\"c\":3}")
 
     // at least that works, there are more in the json than define on the class
     auto j2 = JSON({"a" : 1, "c" : 42});
-    EXPECT_EX("[json.exception.other_error.600] type must have 1 args, but has 2 args, error in: {\"a\":1,\"c\":42}",
-              j2.get<StrictEdgeCase>())
+    EXPECT_EX(j2.get<StrictEdgeCase>(),
+              "[json.exception.other_error.600] key 'c' not present in reflected keys: {\"a\":1,\"c\":42}")
 }

--- a/tests/nlohmann_serialize_test.cpp
+++ b/tests/nlohmann_serialize_test.cpp
@@ -5,7 +5,7 @@
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_ext.hpp>
 
-#include "utils.hpp"
+#include "./utils.hpp"
 
 using nlohmann::json;
 
@@ -70,8 +70,8 @@ TEST(TestNlohmannSerialize, OkayDefaultsPartialOverride)
     EXPECT_EQ(4, obj1.b);
 
     auto obj2 = j.get<OnlyDefaultsStrict>();
-    EXPECT_EQ(1, obj1.a);
-    EXPECT_EQ(4, obj1.b);
+    EXPECT_EQ(1, obj2.a);
+    EXPECT_EQ(4, obj2.b);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -123,18 +123,18 @@ TEST(TestNlohmannSerialize, OkayNonDefaultsFullOverrideMore)
     // fails with strict
     EXPECT_EX("[json.exception.other_error.600] type must have 2 args, but has 3 args, error in:"
               " {\"a\":3,\"b\":4,\"c\":5}",
-              j.get<OnlyNonDefaultsStrict>());
+              j.get<OnlyNonDefaultsStrict>())
 }
 
 TEST(TestNlohmannSerialize, FailNonDefaultsValueMissing)
 {
     auto j = JSON({"a" : 3});
-    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<OnlyNonDefaults>());
-    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<OnlyNonDefaultsStrict>());
+    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<OnlyNonDefaults>())
+    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<OnlyNonDefaultsStrict>())
 
     j = JSON({"b" : 4});
-    EXPECT_EX("[json.exception.out_of_range.403] key 'a' not found", j.get<OnlyNonDefaults>());
-    EXPECT_EX("[json.exception.out_of_range.403] key 'a' not found", j.get<OnlyNonDefaultsStrict>());
+    EXPECT_EX("[json.exception.out_of_range.403] key 'a' not found", j.get<OnlyNonDefaults>())
+    EXPECT_EX("[json.exception.out_of_range.403] key 'a' not found", j.get<OnlyNonDefaultsStrict>())
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -176,8 +176,8 @@ TEST(TestNlohmannSerialize, FailMixedDefaultNonDefault)
 {
     auto j = JSON({"c" : 3});
 
-    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<MixedDefaultNonDefault>());
-    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<MixedDefaultNonDefaultStrict>());
+    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<MixedDefaultNonDefault>())
+    EXPECT_EX("[json.exception.out_of_range.403] key 'b' not found", j.get<MixedDefaultNonDefaultStrict>())
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -196,5 +196,5 @@ TEST(TestNlohmannSerialize, FailStrictEdgeCase)
     // at least that works, there are more in the json than define on the class
     auto j2 = JSON({"a" : 1, "c" : 42});
     EXPECT_EX("[json.exception.other_error.600] type must have 1 args, but has 2 args, error in: {\"a\":1,\"c\":42}",
-              j2.get<StrictEdgeCase>());
+              j2.get<StrictEdgeCase>())
 }

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -20,11 +20,11 @@ TEST(TestOptional, Okay)
 {
     auto j = JSON({"opt" : null});
     auto obj = Optional();
-    EXPECT_EQ(j, static_cast<json>(obj));
-    EXPECT_EQ(j.dump(), static_cast<json>(obj).dump());
+    EXPECT_EQ(static_cast<json>(obj), j);
+    EXPECT_EQ(static_cast<json>(obj).dump(), j.dump());
 
     j = JSON({"opt" : 42});
     obj = j.get<Optional>();
-    EXPECT_EQ(j, static_cast<json>(obj));
-    EXPECT_EQ(j.dump(), static_cast<json>(obj).dump());
+    EXPECT_EQ(static_cast<json>(obj), j);
+    EXPECT_EQ(static_cast<json>(obj).dump(), j.dump());
 }

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define EXPECT_EX(expected_exception_msg, function)                                                                    \
+#define EXPECT_EX(function, expected_exception_msg)                                                                    \
     {                                                                                                                  \
         bool exception_thrown = false;                                                                                 \
         const char *what;                                                                                              \

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #define EXPECT_EX(expected_exception_msg, function)                                                                    \
     {                                                                                                                  \
         bool exception_thrown = false;                                                                                 \

--- a/tests/variant_test.cpp
+++ b/tests/variant_test.cpp
@@ -3,6 +3,8 @@
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_ext.hpp>
 
+#include "./utils.hpp"
+
 struct A
 {
     // clang-format off
@@ -42,4 +44,92 @@ TEST(TestVariant, Okay)
 
     ba = j.get<BA>();
     EXPECT_TRUE(std::holds_alternative<B>(ba));
+}
+
+struct WithOptionalA
+{
+    // clang-format off
+    NLOHMANN_SERIALIZE_STRICT(WithOptionalA,
+        (int, a, 1)
+        (int, b)
+    )
+    // clang-format on
+};
+
+struct WithOptionalB
+{
+    // clang-format off
+    NLOHMANN_SERIALIZE_STRICT(WithOptionalB,
+        (int, a, 1)
+        (int, c, 2)
+    )
+    // clang-format on
+};
+
+using WithOptionalAB = std::variant<WithOptionalA, WithOptionalB>;
+using WithOptionalBA = std::variant<WithOptionalB, WithOptionalA>;
+
+TEST(TestVariant, OkayWithOptionals)
+{
+    auto j1 = JSON({"a" : 1, "b" : 2, "c" : 3});
+    EXPECT_EX(j1.get<WithOptionalAB>(),
+              "[json.exception.other_error.601] unable to find matching variant for: {\"a\":1,\"b\":2,\"c\":3}");
+    EXPECT_EX(j1.get<WithOptionalBA>(),
+              "[json.exception.other_error.601] unable to find matching variant for: {\"a\":1,\"b\":2,\"c\":3}");
+
+    auto j2 = JSON({"a" : 1, "b" : 2});
+    auto v2_ab = j2.get<WithOptionalAB>();
+    auto v2_ba = j2.get<WithOptionalBA>();
+    EXPECT_TRUE(std::holds_alternative<WithOptionalA>(v2_ab));
+    EXPECT_TRUE(std::holds_alternative<WithOptionalA>(v2_ba));
+
+    auto j3 = JSON({"a" : 1, "c" : 2});
+    auto v3_ab = j3.get<WithOptionalAB>();
+    auto v3_ba = j3.get<WithOptionalBA>();
+    EXPECT_TRUE(std::holds_alternative<WithOptionalB>(v3_ab));
+    EXPECT_TRUE(std::holds_alternative<WithOptionalB>(v3_ba));
+}
+
+struct StrictTypeIntersectionA
+{
+    // clang-format off
+    NLOHMANN_SERIALIZE_STRICT(StrictTypeIntersectionA,
+        (int, a)
+    )
+    // clang-format on
+};
+
+struct StrictTypeIntersectionB
+{
+    // clang-format off
+    NLOHMANN_SERIALIZE_STRICT(StrictTypeIntersectionB,
+        (int, a)
+        (int, b, 2)
+    )
+    // clang-format on
+};
+
+using StrictTypeIntersectionAB = std::variant<StrictTypeIntersectionA, StrictTypeIntersectionB>;
+using StrictTypeIntersectionBA = std::variant<StrictTypeIntersectionB, StrictTypeIntersectionA>;
+
+TEST(TestVariant, OkayStrictTypeIntersection)
+{
+    auto j1 = JSON({"a" : 1, "b" : 2, "c" : 3});
+    EXPECT_EX(j1.get<StrictTypeIntersectionAB>(),
+              "[json.exception.other_error.601] unable to find matching variant for: {\"a\":1,\"b\":2,\"c\":3}");
+    EXPECT_EX(j1.get<StrictTypeIntersectionBA>(),
+              "[json.exception.other_error.601] unable to find matching variant for: {\"a\":1,\"b\":2,\"c\":3}");
+
+    auto j2 = JSON({"a" : 1});
+    auto v2_ab = j2.get<StrictTypeIntersectionAB>();
+    auto v2_ba = j2.get<StrictTypeIntersectionBA>();
+    // edge case this effects the type depending on the variant order
+    EXPECT_TRUE(std::holds_alternative<StrictTypeIntersectionA>(v2_ab));
+    EXPECT_TRUE(std::holds_alternative<StrictTypeIntersectionB>(v2_ba));
+
+    auto j3 = JSON({"a" : 1, "b" : 2});
+    auto v3_ab = j3.get<StrictTypeIntersectionAB>();
+    auto v3_ba = j3.get<StrictTypeIntersectionBA>();
+    EXPECT_TRUE(std::holds_alternative<StrictTypeIntersectionB>(v3_ab));
+    EXPECT_TRUE(std::holds_alternative<StrictTypeIntersectionB>(v3_ba));
 }


### PR DESCRIPTION
Improve strict parsing:
- reflect the serialized keys as a `vector<string>`
- before starting to deserialize, check that every key in the json, is also part of the reflected set
- still leaves a special case open for variants see readme.